### PR TITLE
[Feature] Custom Exception Classes Recognition

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,4 +35,4 @@ jobs:
     # Run tests
     - name: Run tests
       run: |
-        poerty run pytest .
+        poetry run pytest .

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checkout the code from the repository
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    # Set up Python
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        export PATH="$HOME/.local/bin:$PATH"
+
+    # Install dependencies
+    - name: Install dependencies
+      run: |
+        poetry install --with tests,dev
+
+    # Run tests
+    - name: Run tests
+      run: |
+        poerty run pytest .

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
+### VsCode ##
+.vscode
+
 ### PyCharm ###
 .idea
 
 ### Cache ###
 __pycache__
 .ruff_cache
+.pytest_cache

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+# pytest.ini
+[pytest]
+testpaths = tests
+python_files = test*.py
+python_functions = test_*
+addopts = --disable-warnings
+verbosity = 2

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -1,0 +1,5 @@
+from starlette.exceptions import HTTPException
+
+
+class ImportedCustomException(HTTPException):
+    ...

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from fastapi_derive_responses import AutoDeriveResponsesAPIRoute
+from tests.exceptions import ImportedCustomException
+
+
+def test_custom_exception_in_source():
+    from fastapi import HTTPException
+
+    class CustomException(HTTPException):
+        ...
+
+    app = FastAPI(title="Custom Exception App")
+    app.router.route_class = AutoDeriveResponsesAPIRoute
+
+    @app.get("/")
+    def raise_custom_exception():
+        raise CustomException(status_code=601, detail="CustomException!")
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    actual_dict = response.json()
+    responses = actual_dict["paths"]["/"]["get"]["responses"]
+    assert responses.get("601") == {"description": "CustomException!"}
+
+
+def test_imported_custom_exception_in_source():
+    app = FastAPI(title="Custom Exception App")
+    app.router.route_class = AutoDeriveResponsesAPIRoute
+
+    @app.get("/")
+    def raise_custom_exception():
+        raise ImportedCustomException(status_code=601, detail="CustomException!")
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    actual_dict = response.json()
+    responses = actual_dict["paths"]["/"]["get"]["responses"]
+    assert responses.get("601") == {"description": "CustomException!"}

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from fastapi_derive_responses import AutoDeriveResponsesAPIRoute
+
+def test_fake_http_exception_in_source():
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str):
+            pass
+
+    app = FastAPI(title="Custom Exception App")
+    app.router.route_class = AutoDeriveResponsesAPIRoute
+
+    @app.get("/")
+    def raise_custom_exception():
+        raise HTTPException(status_code=601, detail="CustomException!")
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    actual_dict = response.json()
+    responses = actual_dict["paths"]["/"]["get"]["responses"]
+    assert responses.get("601") is None


### PR DESCRIPTION
# [Feature] Custom Exception Classes Recognition
## What changed:
- [x] Avoid false positives (e.g., `raise HTTPException(401)` where `HTTPException` is not from `starlette` or
  `fastapi`)
- [x] Parse custom classes that inherit from `HTTPException`

### Description:
This PR added the `_inspect_function_source` function to better handle the inspection of imported and defined classes. It ensures that only relevant `HTTPException` subclasses are identified, avoiding false positives from other modules, and correctly parses custom classes that inherit from `HTTPException`.

### Implementation Details:
- Reads file content and parses it into an AST.
- Walks through the AST to extract import details and dynamically imports modules.
- Checks if imported objects are subclasses of `HTTPException`.
- Identifies defined classes within the AST and checks their inheritance.


### Considered testcases
 - Custom class inherited from HTTPException
 - Custom class inherited from HTTPException imported from other module
 - Fake HTTPException class
 
 ### Problem case 
 
 Module now can't recognize HTTException fake class, if HTTException is imported in different scope
 
 Short example:
```python
...

def dummy():
    from starlette.exceptions import HTTPException # Considered as import in head of file
    ....

class HTTPException(Exception):
    def __init__(self, status_code: int, detail: str):
        pass

@app.get("/")
def raise_custom_exception():
    raise HTTPException(status_code=601, detail="CustomException!") # This error will be considered as starlette.HTTPException subclass
```

Reason for this no scope is considered for imports
 
## Minor changes:
- Added CI for tests
- Add `pytest.ini`
 